### PR TITLE
String format method flagged incorrect syntax in voice.py

### DIFF
--- a/googlevoice/voice.py
+++ b/googlevoice/voice.py
@@ -114,7 +114,7 @@ class Voice(object):
             while "The code you entered didn&#39;t verify." in content and try_count < 5:
                 sleep_seconds = 10
                 try_count += 1
-                print('invalid code, retrying after %s seconds (attempt %s)' % sleep_seconds, try_count)
+                print('invalid code, retrying after %s seconds (attempt %s)' % (sleep_seconds, try_count))
                 import time
                 time.sleep(sleep_seconds)
                 content = self.__oathtoolAuth(smsKey)

--- a/googlevoice/voice.py
+++ b/googlevoice/voice.py
@@ -114,7 +114,7 @@ class Voice(object):
             while "The code you entered didn&#39;t verify." in content and try_count < 5:
                 sleep_seconds = 10
                 try_count += 1
-                print 'invalid code, retrying after {0} seconds (attempt {1})'.format(sleep_seconds, try_count)
+                print('invalid code, retrying after %s seconds (attempt %s)' % sleep_seconds, try_count)
                 import time
                 time.sleep(sleep_seconds)
                 content = self.__oathtoolAuth(smsKey)


### PR DESCRIPTION
Modified the voice.py script to use %s string formatting instead of calling the format method. 

Currently running version Python 3.5.0 and the build script failed to compile the voice.py binary with the previous code. 