### PR TITLE
Bug fix for compatibility with Python 3

### DIFF
--- a/googlevoice/conf.py
+++ b/googlevoice/conf.py
@@ -25,9 +25,9 @@ class Config(ConfigParser):
         except IOError:
             return
 
-    def get(self, option, section='gvoice'):
+    def get(self, option, section='gvoice', **kwargs):
         try:
-            return ConfigParser.get(self, section, option).strip() or None
+            return ConfigParser.get(self, section, option, **kwargs).strip() or None
         except NoOptionError:
             return
 


### PR DESCRIPTION
Python 3 added a few keyword arguments to the get() method of ConfigParser.  An error is generated in Config whenever ConfigParser tries to pass an argument to the get() method that Config's get() method does not support.  (This occurs when the email and password are read from the .gvoice file.)  This correction adds keyword arguments to Config's get() method and passes them through to ConfigParser's get() method so that these errors are avoided.
